### PR TITLE
Implemented empty filter constraint, fixed crash on empty queries

### DIFF
--- a/src/app/Common/DAL/BaseFilter.cs
+++ b/src/app/Common/DAL/BaseFilter.cs
@@ -3,6 +3,6 @@
     public class BaseFilter
     {
         public string Id { get; set; }
-        public bool EmptyFilterAllowed { get; set; }
+        public bool IsEmptyFilterAllowed { get; set; }
     }
 }

--- a/src/app/Common/DAL/BaseFilter.cs
+++ b/src/app/Common/DAL/BaseFilter.cs
@@ -3,5 +3,6 @@
     public class BaseFilter
     {
         public string Id { get; set; }
+        public bool EmptyFilterAllowed { get; set; }
     }
 }

--- a/src/app/Common/DAL/BaseRepository.cs
+++ b/src/app/Common/DAL/BaseRepository.cs
@@ -108,7 +108,14 @@ namespace Common.DAL
                 filterQueries.Add(GetFilterById(filter.Id));
             }
 
-            return Builders<TDocument>.Filter.And(filterQueries);
+            if (!filterQueries.Any() && !filter.EmptyFilterAllowed)
+            {
+                throw new ApplicationException("Empty filter is not allowed");
+            }
+
+            return filterQueries.Any()
+                ? Builders<TDocument>.Filter.And(filterQueries)
+                : FilterDefinition<TDocument>.Empty;
         }
 
         private static FilterDefinition<TDocument> GetFilterById(string id)

--- a/src/app/Common/DAL/BaseRepository.cs
+++ b/src/app/Common/DAL/BaseRepository.cs
@@ -108,7 +108,7 @@ namespace Common.DAL
                 filterQueries.Add(GetFilterById(filter.Id));
             }
 
-            if (!filterQueries.Any() && !filter.EmptyFilterAllowed)
+            if (!filterQueries.Any() && !filter.IsEmptyFilterAllowed)
             {
                 throw new ApplicationException("Empty filter is not allowed");
             }


### PR DESCRIPTION
If users specifies empty mongo filter BaseRepository crashes in BuildFilterQuery return statement:
`"$and/$or/$nor must be a nonempty array"`
Fixed that issue.

Also implemented (copypasted Stepan's solution from ServGrow) constraint on empty filter as caution for developer when filter is used in update operations 